### PR TITLE
Add md5 plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>fusionauth-plugin-api</artifactId>
       <version>1.15.8</version>

--- a/src/main/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptor.java
+++ b/src/main/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptor.java
@@ -1,0 +1,42 @@
+package com.company.fusionauth.plugins;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import javax.xml.bind.DatatypeConverter;
+
+import io.fusionauth.plugin.spi.security.PasswordEncryptor;
+
+/**
+ * 
+ * @author Daniel DeGroff
+ *
+ */
+public class CustomMD5SaltedEncryptor implements PasswordEncryptor {
+    @Override
+    public int defaultFactor() {
+      return 1;
+    }
+
+    @Override
+    public String encrypt(String password, String salt, int factor) {
+      if (factor <= 0) {
+        throw new IllegalArgumentException("Invalid factor value [" + factor + "]");
+      }
+
+      MessageDigest messageDigest;
+      try {
+        messageDigest = MessageDigest.getInstance("MD5");
+      } catch (NoSuchAlgorithmException e) {
+        throw new IllegalArgumentException("No such algorithm [MD5]");
+      }
+
+      byte[] digest = (salt + password).getBytes(StandardCharsets.US_ASCII);
+      for (int i = 0; i < factor; i++) {
+        digest = messageDigest.digest(digest);
+      }
+
+      return DatatypeConverter.printHexBinary(digest);
+    }
+  }
+

--- a/src/main/java/com/company/fusionauth/plugins/guice/MyFusionAuthPluginModule.java
+++ b/src/main/java/com/company/fusionauth/plugins/guice/MyFusionAuthPluginModule.java
@@ -1,5 +1,6 @@
 package com.company.fusionauth.plugins.guice;
 
+import com.company.fusionauth.plugins.CustomMD5SaltedEncryptor;
 import com.company.fusionauth.plugins.MyExamplePasswordEncryptor;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
@@ -19,5 +20,6 @@ public class MyFusionAuthPluginModule extends AbstractModule {
     //   1. Add one or more bindings here
     //   2. Name your binding. This will be the value you set in the 'encryptionScheme' on the user to utilize this encryptor.
     passwordEncryptorMapBinder.addBinding("example-hash").to(MyExamplePasswordEncryptor.class);
+    passwordEncryptorMapBinder.addBinding("custom-md5").to(CustomMD5SaltedEncryptor.class);
   }
 }

--- a/src/test/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptorTest.java
+++ b/src/test/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptorTest.java
@@ -1,0 +1,19 @@
+package com.company.fusionauth.plugins;
+
+import io.fusionauth.plugin.spi.security.PasswordEncryptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel DeGroff
+ */
+public class CustomMD5SaltedEncryptorTest {
+
+  @Test
+  public void encrypt() {
+    // TODO : Assert that a plain text password matches an expected hash.
+    PasswordEncryptor encryptor = new CustomMD5SaltedEncryptor();
+    String result = encryptor.encrypt("password", "4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2", 1);
+    Assert.assertEquals(result, "e0198a696980741ec49e2c56615fbc98".toUpperCase());
+  }
+}

--- a/src/test/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptorTest.java
+++ b/src/test/java/com/company/fusionauth/plugins/CustomMD5SaltedEncryptorTest.java
@@ -11,7 +11,6 @@ public class CustomMD5SaltedEncryptorTest {
 
   @Test
   public void encrypt() {
-    // TODO : Assert that a plain text password matches an expected hash.
     PasswordEncryptor encryptor = new CustomMD5SaltedEncryptor();
     String result = encryptor.encrypt("password", "4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2", 1);
     Assert.assertEquals(result, "e0198a696980741ec49e2c56615fbc98".toUpperCase());


### PR DESCRIPTION
Pulled a sample md5 plugin from https://github.com/fusionAuth/fusionauth-issues/issues/204 and put it in here with tests. Given @robotdan wrote the code, I added his name to the comments, all I did was port it over.

I'm not sure how much we should disclaim the md5 encryptor as being unfit for production use.