### PR TITLE
Feature/argon2id encryptor

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,6 +13,7 @@ project(group: "io.fusionauth", name: "fusionauth-example-password-encryptor", v
     group(name: "compile") {
       dependency(id: "com.google.inject:guice:4.2.3")
       dependency(id: "com.google.inject.extensions:guice-multibindings:4.2.3")
+      dependency(id: "de.mkammerer:argon2-jvm:2.9.1")
     }
     group(name: "provided") {
       dependency(id: "io.fusionauth:fusionauth-plugin-api:1.15.8")

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>de.mkammerer</groupId>
+      <artifactId>argon2-jvm</artifactId>
+      <version>2.9.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>fusionauth-plugin-api</artifactId>
       <version>1.15.8</version>

--- a/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
+++ b/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
@@ -22,7 +22,6 @@ import java.util.Base64;
 import de.mkammerer.argon2.Argon2Advanced;
 import de.mkammerer.argon2.Argon2Factory;
 
-import com.mycompany.fusionauth.util.HexTools;
 import io.fusionauth.plugin.spi.security.PasswordEncryptor;
 
 

--- a/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
+++ b/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package com.mycompany.fusionauth.plugins;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import de.mkammerer.argon2.Argon2Advanced;
+import de.mkammerer.argon2.Argon2Factory;
+
+import com.mycompany.fusionauth.util.HexTools;
+import io.fusionauth.plugin.spi.security.PasswordEncryptor;
+
+
+/**
+ * This is an example of an Argon2id hashing algorithm.
+ *
+ * <p>
+ * This code is provided to assist in your deployment and management of FusionAuth. Use of this
+ * software is not covered under the FusionAuth license agreement and is provided "as is" without
+ * warranty. https://fusionauth.io/license
+ * </p>
+ *
+ * @author Matthew Hartstonge
+ * @see <a href="https://tools.ietf.org/html/draft-irtf-cfrg-argon2-12"> Argon2 IETF RFC </a>
+ * @see <a href="https://github.com/phxql/argon2-jvm"> Argon2-jvm Github Repo </a>
+ * @see <a href="https://github.com/P-H-C/phc-winner-argon2/blob/master/argon2-specs.pdf"> Original Argon2 Whitepaper </a>
+ */
+public class ExampleArgon2idPasswordEncryptor implements PasswordEncryptor {
+    private final Argon2Advanced argon2;
+
+    /**
+     * timeCost (t), specifies a number of passes (iterations) used to tune the
+     * running time independently of the memory size.
+     */
+    private int timeCost;
+
+    /**
+     * memoryCost (m), specifies the hashing memory size in kibibytes.
+     */
+    private int memoryCost;
+
+    /**
+     * parallelism (p), specifies the degree of parallelism, which is how many
+     * independent (but synchronizing) computational chains (lanes/thread) can
+     * be run.
+     */
+    private int parallelism;
+
+    public ExampleArgon2idPasswordEncryptor() {
+        this.setMemoryCost(64);
+        this.setParallelism(1);
+        this.setTimeCost(this.defaultFactor());
+        this.argon2 = Argon2Factory.createAdvanced(Argon2Factory.Argon2Types.ARGON2id);
+    }
+
+    @Override
+    public int defaultFactor() {
+        // The Argon2id variant with t=1 and maximum available memory is
+        // RECOMMENDED as a default setting for all environments.
+        //
+        // Refer: https://tools.ietf.org/html/draft-irtf-cfrg-argon2-12#section-7.4
+        return 1;
+    }
+
+    @Override
+    public String encrypt(String password, String salt, int factor) {
+        this.setTimeCost(factor);
+
+        String hash = this.argon2.hash(
+                this.timeCost,
+                this.memoryCost,
+                this.parallelism,
+                password.toCharArray(),
+                StandardCharsets.UTF_8,
+                Base64.getDecoder().decode(salt)
+        );
+
+        return new String(Base64.getEncoder().encode(hash.getBytes()));
+    }
+
+    /**
+     * setTimeCost configures the cost of iterations.
+     *
+     * @param timeCost - The number of passes (time cost/iterations) to use when hashing.
+     * @throws IllegalArgumentException - If an invalid time cost is configured.
+     */
+    public void setTimeCost(int timeCost) {
+        if (timeCost < 1) {
+            throw new IllegalArgumentException("Invalid Time Cost value [" + timeCost + "] it must be an integer greater, or equal to 1");
+        }
+
+        this.timeCost = timeCost;
+    }
+
+    /**
+     * setMemoryCost sets the memory cost in megabytes.
+     *
+     * @param memory - The amount of memory in megabytes to use when hashing.
+     * @throws IllegalArgumentException - If an invalid memory cost is provided.
+     */
+    public void setMemoryCost(int memory) {
+        int kibibytes = memory * 1024;
+        if (kibibytes < 1 || kibibytes > 16_777_215) {
+            throw new IllegalArgumentException("Invalid Memory Cost value [" + memory + "] it must be an integer from 1 to 16,383 ((2^(24)-1)/1024).");
+        }
+
+        this.memoryCost = kibibytes;
+    }
+
+    /**
+     * setParallelism sets the degree of parallelism to use when hashing.
+     *
+     * @param parallelism - The degree of parallelism to use when hashing.
+     * @throws IllegalArgumentException - If an invalid degree of parallelism is provided.
+     */
+    public void setParallelism(int parallelism) {
+        if (parallelism < 1) {
+            throw new IllegalArgumentException("Invalid Parallelism value [" + parallelism + "] it must be an integer greater, or equal to 1");
+        }
+
+        this.parallelism = parallelism;
+    }
+}

--- a/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
+++ b/src/main/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptor.java
@@ -15,7 +15,6 @@
  */
 package com.mycompany.fusionauth.plugins;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/src/main/java/com/mycompany/fusionauth/plugins/guice/MyExampleFusionAuthPluginModule.java
+++ b/src/main/java/com/mycompany/fusionauth/plugins/guice/MyExampleFusionAuthPluginModule.java
@@ -17,6 +17,7 @@ package com.mycompany.fusionauth.plugins.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
+import com.mycompany.fusionauth.plugins.ExampleArgon2idPasswordEncryptor;
 import com.mycompany.fusionauth.plugins.ExampleCustomMD5SaltedPasswordEncryptor;
 import com.mycompany.fusionauth.plugins.ExamplePBDKF2HMACSHA1PasswordEncryptor;
 import com.mycompany.fusionauth.plugins.ExampleRfc2898DeriveBytesPasswordEncryptor;
@@ -52,5 +53,9 @@ public class MyExampleFusionAuthPluginModule extends AbstractModule {
     // Rfc2898DeriveBytes
     // https://github.com/aspnet/AspNetIdentity/blob/master/src/Microsoft.AspNet.Identity.Core/Crypto.cs#L26
     passwordEncryptorMapBinder.addBinding("example-Rfc2898DeriveBytes").to(ExampleRfc2898DeriveBytesPasswordEncryptor.class);
+
+    // Argon2id
+    // https://github.com/P-H-C/phc-winner-argon2
+    passwordEncryptorMapBinder.addBinding("example-argon2id").to(ExampleArgon2idPasswordEncryptor.class);
   }
 }

--- a/src/test/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptorTest.java
+++ b/src/test/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package com.mycompany.fusionauth.plugins;
+
+import io.fusionauth.plugin.spi.security.PasswordEncryptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Base64;
+
+/**
+ * @author Matthew Hartstonge
+ */
+public class ExampleArgon2idPasswordEncryptorTest {
+    @Test
+    public void encrypt() {
+        // Test control input and output to ensure the hash is correct.
+        PasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
+        String result = encryptor.encrypt("password", "4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2", 1);
+        Assert.assertEquals(result, new String(Base64.getEncoder().encode("$argon2id$v=19$m=65536,t=1,p=1$4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2$RM2FCk53pEw2en0JWtoIqWu3c9xJvhb/7GRx8KkX9kU".getBytes())));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void Should_ThrowException_When_TimeCostLessThan1() {
+        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
+        encryptor.setTimeCost(0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void Should_ThrowException_When_MemoryLessThan1() {
+        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
+        encryptor.setMemoryCost(0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void Should_ThrowException_When_MemoryGreaterThan16_777_215Kibibytes() {
+        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
+        encryptor.setMemoryCost(16384);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void Should_ThrowException_When_ParallelismLessThan1() {
+        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
+        encryptor.setParallelism(0);
+    }
+}


### PR DESCRIPTION
Adds example argon2id encryptor.

Follows from conversation at: https://github.com/FusionAuth/fusionauth-issues/issues/997#issuecomment-792422389

Notes:
- I've b64 encoded the "stringy" representation of the argon2 hash here instead of the direct b64 encoded argon bytes. Thoughts?