### PR TITLE
Bugfix/argon2id-bouncy-castle-with-shade

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -14,10 +14,7 @@ project(group: "io.fusionauth", name: "fusionauth-example-password-encryptor", v
       dependency(id: "com.google.inject:guice:4.2.3")
       dependency(id: "com.google.inject.extensions:guice-multibindings:4.2.3")
       // Required for the Argon2 Plugin.
-      // argon-jvm
-      //    \__ argon2-jvm-nolibs
-      dependency(id: "de.mkammerer:argon2-jvm:2.9.1")
-      dependency(id: "de.mkammerer:argon2-jvm-nolibs:2.9.1")
+      dependency(id: "org.bouncycastle:bcprov-jdk15on:1.69")
     }
     group(name: "provided") {
       dependency(id: "io.fusionauth:fusionauth-plugin-api:1.15.8")

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,15 @@
       <version>4.2.3</version>
       <scope>compile</scope>
     </dependency>
+    <!-- Required for the Argon2 Plugin.
+      https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
+    -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.69</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>fusionauth-plugin-api</artifactId>
@@ -79,22 +88,6 @@
       <artifactId>testng</artifactId>
       <version>6.14.3</version>
       <scope>test</scope>
-    </dependency>
-    <!-- Required for the Argon2 Plugin.
-          argon-jvm
-            |__ argon2-jvm-nolibs
-    -->
-    <dependency>
-      <groupId>de.mkammerer</groupId>
-      <artifactId>argon2-jvm</artifactId>
-      <version>2.9.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.mkammerer</groupId>
-      <artifactId>argon2-jvm-nolibs</artifactId>
-      <version>2.9.1</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,36 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <artifactSet>
+                <includes>
+                  <include>org.bouncycastle:bcprov-jdk15on</include>
+                </includes>
+              </artifactSet>
+
+              <transformers>
+                <!-- exclude dependency manifest files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>MANIFEST.MF</resource>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/test/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptorTest.java
+++ b/src/test/java/com/mycompany/fusionauth/plugins/ExampleArgon2idPasswordEncryptorTest.java
@@ -17,43 +17,35 @@ package com.mycompany.fusionauth.plugins;
 
 import io.fusionauth.plugin.spi.security.PasswordEncryptor;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
  * @author Matthew Hartstonge
  */
 public class ExampleArgon2idPasswordEncryptorTest {
-    @Test
-    public void encrypt() {
-        // Test control input and output to ensure the hash is correct.
+    @Test(dataProvider = "hashes")
+    public void encrypt(String password, String salt, int factor, String expected) {
         PasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
-        String result = encryptor.encrypt("password", "4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2", 1);
-        Assert.assertEquals(result, new String(Base64.getEncoder().encode("$argon2id$v=19$m=65536,t=1,p=1$4MTVxbvk8swI0ys2Lf4saeR3swRvn0f2$RM2FCk53pEw2en0JWtoIqWu3c9xJvhb/7GRx8KkX9kU".getBytes())));
+        String actual = encryptor.encrypt(password, b64Encode(salt), factor);
+        Assert.assertEquals(actual, expected);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void Should_ThrowException_When_TimeCostLessThan1() {
-        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
-        encryptor.setTimeCost(0);
+    @DataProvider(name = "hashes")
+    public Object[][] hashes() {
+        return new Object[][]{
+                {"password123", "saltysalt", 1, "$argon2id$v=19$m=65536,t=1,p=4$c2FsdHlzYWx0$4FnTpZaINA9WWoTmhm1Y5BNP0ueQGQWWPIARybMRN64"},
+                {"password123", "saltysalt", 2, "$argon2id$v=19$m=65536,t=2,p=4$c2FsdHlzYWx0$BmD1EnGoAaDtGRiQ4nlW+pGIvHIHT+tW1F8xaWdxDQE"},
+                {"password123", "2qUAZD49DpdiOnxQqRHddpBg0Rfb36NM4ZPSDTLCz6cM2MWQx0", 3, "$argon2id$v=19$m=65536,t=3,p=4$MnFVQVpENDlEcGRpT254UXFSSGRkcEJnMFJmYjM2Tk00WlBTRFRMQ3o2Y00yTVdReDA$WFpsLuNnmVrfVO3TRw5p6mtvv3ryDbNzyHzY/CN8/ow"},
+                {"password123", "2TR5SPOtQBW62Y1Ju6brUBmd1HlPyfOrGlakmvTUFC5q3JvT1e", 3, "$argon2id$v=19$m=65536,t=3,p=4$MlRSNVNQT3RRQlc2MlkxSnU2YnJVQm1kMUhsUHlmT3JHbGFrbXZUVUZDNXEzSnZUMWU$5P4NBHMf3gSsBbiQc2PVPDUiGNPAT4YWEwOTHwk3aCA"},
+                {"password321", "2TR5SPOtQBW62Y1Ju6brUBmd1HlPyfOrGlakmvTUFC5q3JvT1e", 3, "$argon2id$v=19$m=65536,t=3,p=4$MlRSNVNQT3RRQlc2MlkxSnU2YnJVQm1kMUhsUHlmT3JHbGFrbXZUVUZDNXEzSnZUMWU$ZGS+lgDik0LcF2T5m9p7+8OhoH5oztUuo4Po4hruK5w"},
+        };
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void Should_ThrowException_When_MemoryLessThan1() {
-        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
-        encryptor.setMemoryCost(0);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void Should_ThrowException_When_MemoryGreaterThan16_777_215Kibibytes() {
-        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
-        encryptor.setMemoryCost(16384);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void Should_ThrowException_When_ParallelismLessThan1() {
-        ExampleArgon2idPasswordEncryptor encryptor = new ExampleArgon2idPasswordEncryptor();
-        encryptor.setParallelism(0);
+    private String b64Encode(String in) {
+        return new String(Base64.getEncoder().encode(in.getBytes(StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
* Migrates from `de.mkammerer:argon2-jvm:2.9.1` to `org.bouncycastle:bcprov-jdk15on:1.69` for a pure Java experience.
* Shades third-party dependencies to produce a single 'uber' JAR.

Fixes: https://github.com/FusionAuth/fusionauth-issues/issues/1464